### PR TITLE
Fix clang-format path variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ else()
   add_custom_target(format
     ${PYTHON_EXECUTABLE} ${GCF_SCRIPT}
     --cmake ${GIT_EXECUTABLE}
-    ${CLANG_FORMAT_EXECUTABLE} -style=${GCF_CLANGFORMAT_STYLE}
+    ${ClangFormat_EXECUTABLE} -style=${GCF_CLANGFORMAT_STYLE}
     -ignore=${GCF_IGNORE_LIST}
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
   unset(GCF_SCRIPT)

--- a/git-pre-commit-hook
+++ b/git-pre-commit-hook
@@ -4,6 +4,6 @@
 	"@GCF_SCRIPT@" \
 	"--pre-commit" \
 	"@GIT_EXECUTABLE@" \
-	"@CLANG_FORMAT_EXECUTABLE@" \
+	"@ClangFormat_EXECUTABLE@" \
 	"-style=@GCF_CLANGFORMAT_STYLE@" \
 	"-ignore=@GCF_IGNORE_LIST@"


### PR DESCRIPTION
In the last PR, we changed the variable name for the clang-format executable only in some places, which caused the pre-commit hook to contain an empty string instead of the executable location, and the `make format` target to fail. This PR changes that variable in the remaining locations.