### PR TITLE
add --assume-filename

### DIFF
--- a/git-cmake-format.py
+++ b/git-cmake-format.py
@@ -57,7 +57,7 @@ def requiresFormat(FileName):
     GitShowRet = subprocess.Popen([Git, "show", ":" + FileName],
             stdout=subprocess.PIPE)
     ClangFormatRet = subprocess.Popen(
-            [ClangFormat, Style], stdin=GitShowRet.stdout, stdout=subprocess.PIPE)
+            [ClangFormat, Style, '--assume-filename=' + FileName], stdin=GitShowRet.stdout, stdout=subprocess.PIPE)
     FormattedContent = ClangFormatRet.stdout.read()
 
 


### PR DESCRIPTION
In MacOS, clang-format (8.0.0 and 9.0.0) identifies `omp/solver/gmres.cpp` as  Objective-C not C++.
It gives error `Configuration file(s) do(es) not support Objective-C` when `omp/solver/gmres.cpp` is in stage.

add `--assume-filename=FileName` to ensure that clang-format get correct language.