### PR TITLE
Update minimal CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(git-clang-format-cmake)
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 
 find_package(Git REQUIRED)
 find_package(PythonInterp REQUIRED)


### PR DESCRIPTION
This silences warnings in more recent CMake versions in Ginkgo:
```
CMake Deprecation Warning at build/third_party/git-cmake-format/src/CMakeLists.txt:2 (cmake_minimum_required):
Compatibility with CMake < 2.8.12 will be removed from a future version of CMake.

Update the VERSION argument <min> value or use a ...<max> suffix to tell
CMake that the project does not need compatibility with older versions.
```