### PR TITLE
fixes handling of multiple worktrees

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,10 +23,11 @@ execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --absolute-git-dir
 if(NOT GCF_GIT_ROOT)
   message(WARNING "Not in a git repository")
 else()
-  set(GCF_SCRIPT_GIT_DIR ${GCF_GIT_ROOT}/hooks/git-cmake-format.py)
+  set(GCF_GIT_DIR_SCRIPT ${GCF_GIT_ROOT}/hooks/git-cmake-format.py)
   configure_file(
-    ${GCF_SCRIPT} ${GCF_SCRIPT_GIT_DIR}
+    ${GCF_SCRIPT} ${GCF_GIT_DIR_SCRIPT}
     COPYONLY)
+  unset(GCF_SCRIPT)
 
   configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/git-pre-commit-hook
@@ -35,11 +36,10 @@ else()
   unset(GCF_GIT_ROOT)
 
   add_custom_target(format
-    ${PYTHON_EXECUTABLE} ${GCF_SCRIPT_GIT_DIR}
+    ${PYTHON_EXECUTABLE} ${GCF_GIT_DIR_SCRIPT}
     --cmake ${GIT_EXECUTABLE}
     ${ClangFormat_EXECUTABLE} -style=${GCF_CLANGFORMAT_STYLE}
     -ignore=${GCF_IGNORE_LIST}
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-  unset(GCF_SCRIPT)
-  unset(GCF_SCRIPT_GIT_DIR)
+  unset(GCF_GIT_DIR_SCRIPT)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,11 @@ execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --absolute-git-dir
 if(NOT GCF_GIT_ROOT)
   message(WARNING "Not in a git repository")
 else()
+  set(GCF_SCRIPT_GIT_DIR ${GCF_GIT_ROOT}/hooks/git-cmake-format.py)
+  configure_file(
+    ${GCF_SCRIPT} ${GCF_SCRIPT_GIT_DIR}
+    COPYONLY)
+
   configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/git-pre-commit-hook
     ${GCF_GIT_ROOT}/hooks/pre-commit
@@ -30,10 +35,11 @@ else()
   unset(GCF_GIT_ROOT)
 
   add_custom_target(format
-    ${PYTHON_EXECUTABLE} ${GCF_SCRIPT}
+    ${PYTHON_EXECUTABLE} ${GCF_SCRIPT_GIT_DIR}
     --cmake ${GIT_EXECUTABLE}
     ${ClangFormat_EXECUTABLE} -style=${GCF_CLANGFORMAT_STYLE}
     -ignore=${GCF_IGNORE_LIST}
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
   unset(GCF_SCRIPT)
+  unset(GCF_SCRIPT_GIT_DIR)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ set(GCF_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/git-cmake-format.py)
 
 find_package(ClangFormat ${GCF_CLANGFORMAT_MINIMAL_VERSION} REQUIRED)
 
-execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --show-toplevel
+execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --absolute-git-dir
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
   OUTPUT_VARIABLE GCF_GIT_ROOT
   OUTPUT_STRIP_TRAILING_WHITESPACE)
@@ -25,7 +25,7 @@ if(NOT GCF_GIT_ROOT)
 else()
   configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/git-pre-commit-hook
-    ${GCF_GIT_ROOT}/.git/hooks/pre-commit
+    ${GCF_GIT_ROOT}/hooks/pre-commit
     @ONLY)
   unset(GCF_GIT_ROOT)
 

--- a/git-pre-commit-hook
+++ b/git-pre-commit-hook
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 "@PYTHON_EXECUTABLE@" \
-	"@GCF_SCRIPT@" \
+	"@GCF_GIT_DIR_SCRIPT@" \
 	"--pre-commit" \
 	"@GIT_EXECUTABLE@" \
 	"@ClangFormat_EXECUTABLE@" \


### PR DESCRIPTION
This PR allows using gingko with multiple worktrees created by `git worktree add`.

The used command is available at least with git 2.26, but I'm not sure about the minimal required version