### PR TITLE
Fix when it is not in git and add some possible clang-format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,10 +22,14 @@ execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --git-path hooks
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
   OUTPUT_VARIABLE GCF_GIT_HOOKS_DIR
   OUTPUT_STRIP_TRAILING_WHITESPACE)
-get_filename_component(GCF_GIT_HOOKS_DIR ${GCF_GIT_HOOKS_DIR} REALPATH BASE_DIR ${CMAKE_SOURCE_DIR})
+
+# If it is not in git, give an error and return
 if(NOT GCF_GIT_HOOKS_DIR)
   message(WARNING "Not in a git repository")
-else()
+  return()
+endif()
+get_filename_component(GCF_GIT_HOOKS_DIR ${GCF_GIT_HOOKS_DIR} REALPATH BASE_DIR ${CMAKE_SOURCE_DIR})
+if(EXISTS "${GCF_GIT_HOOKS_DIR}")
   set(GCF_GIT_DIR_SCRIPT ${GCF_GIT_HOOKS_DIR}/git-cmake-format.py)
   if((NOT GCF_FORCE_OVERWRITE) AND (EXISTS ${GCF_GIT_HOOKS_DIR}/pre-commit))
     message(STATUS "custom hook is already installed, skipping it (overwrite with GCF_FORCE_OVERWRITE=ON)")

--- a/FindClangFormat.cmake
+++ b/FindClangFormat.cmake
@@ -31,7 +31,11 @@
 #    endif()
 
 find_program(ClangFormat_EXECUTABLE
-  NAMES clang-format clang-format-5.0
+  NAMES clang-format clang-format-13 
+        clang-format-12 clang-format-11 
+        clang-format-10 clang-format-9 
+        clang-format-8 clang-format-7 
+        clang-format-6.0 clang-format-5.0
         clang-format-4.0 clang-format-3.9
         clang-format-3.8 clang-format-3.7
         clang-format-3.6 clang-format-3.5


### PR DESCRIPTION
This pr fixes the issue when the folder is not in valid git structure and add some possible clang-format
The folder copied or uploaded to other place leads the cmake error, which is from `get_filename_component`
