### PR TITLE
Allows user to set clang-format executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,10 @@ set(GCF_CLANGFORMAT_STYLE "file" CACHE STRING
     "Parameter pass to clang-format -style=<here>")
 set(GCF_IGNORE_LIST "" CACHE STRING
     "Semi colon separated list of directories to ignore")
-set(GCF_CLANGFORMAT_MINIMAL_VERSION "0.0.0" CACHE STRING
-    "The minimal required version of clang-format")
+set(GCF_CLANGFORMAT_USER_EXECUTABLE "" CACHE STRING
+    "Absolute path to user defined clang-format executable")
+set(GCF_CLANGFORMAT_MINIMAL_VERSION "9.0.0" CACHE STRING
+    "The minimal required version of clang-format, might be necessary to set to 0.0.0 if your clang-format is not found")
 set(GCF_FORCE_OVERWRITE OFF CACHE BOOL
     "If true, always overwrite pre-commit hook and script")
 set(GCF_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/git-cmake-format.py)

--- a/FindClangFormat.cmake
+++ b/FindClangFormat.cmake
@@ -30,18 +30,26 @@
 #              "version: ${ClangFormat_VERSION}")
 #    endif()
 
-find_program(ClangFormat_EXECUTABLE
-  NAMES clang-format clang-format-13 
-        clang-format-12 clang-format-11 
-        clang-format-10 clang-format-9 
-        clang-format-8 clang-format-7 
-        clang-format-6.0 clang-format-5.0
-        clang-format-4.0 clang-format-3.9
-        clang-format-3.8 clang-format-3.7
-        clang-format-3.6 clang-format-3.5
-        clang-format-3.4 clang-format-3.3
-  DOC "clang-format executable"
-)
+if(GCF_CLANGFORMAT_USER_EXECUTABLE)
+  if(NOT EXISTS "${GCF_CLANGFORMAT_USER_EXECUTABLE}")
+    message(FATAL_ERROR "Provided clang-format executable does not exist: ${GCF_CLANGFORMAT_USER_EXECUTABLE}")
+  endif()
+  set(ClangFormat_EXECUTABLE "${GCF_CLANGFORMAT_USER_EXECUTABLE}")
+else()
+  find_program(ClangFormat_EXECUTABLE
+               NAMES clang-format clang-format-15
+               clang-format-14 clang-format-13
+               clang-format-12 clang-format-11
+               clang-format-10 clang-format-9
+               clang-format-8 clang-format-7
+               clang-format-6.0 clang-format-5.0
+               clang-format-4.0 clang-format-3.9
+               clang-format-3.8 clang-format-3.7
+               clang-format-3.6 clang-format-3.5
+               clang-format-3.4 clang-format-3.3
+               DOC "clang-format executable"
+               )
+endif()
 mark_as_advanced(ClangFormat_EXECUTABLE)
 
 # Extract version from command "clang-format -version"


### PR DESCRIPTION
This PR allows users to set the clang-format executable. The `find_progam` part is skipped in that case, instead it is only checked if the provided executable exists. Since that is not enough to check if the executable is working, I've set the minimal version to 9.0.0 (which is used in ubuntu 18.04) to trigger an error, if the user did not provide a working clang-format.

I've also added more clang format names.

PS: This is necessary for me, since my local default clang-format (v13) sometimes disagrees with the one that our check-format action uses. So far, I couldn't figure out which clang-format option is giving these difficulties.